### PR TITLE
Update HTTP method for cancelOrder to POST

### DIFF
--- a/api/calls.js
+++ b/api/calls.js
@@ -274,7 +274,8 @@ module.exports = {
       order_id: {
         required: true
       }
-    }
+    },
+    method: 'POST'
   },
   'getInstruments': {
     description: 'Get instruments list.',

--- a/index.js
+++ b/index.js
@@ -129,6 +129,7 @@ class RobinHood{
 
          return self.parseResult(result);
       }catch(e){
+         console.error(e)
          if('error' in e){
            if(typeof e.error === 'object'){
              let keys = Object.keys(e.error);

--- a/index.js
+++ b/index.js
@@ -130,6 +130,7 @@ class RobinHood{
          return self.parseResult(result);
       }catch(e){
          console.error(e)
+         console.trace('Trace...')
          if('error' in e){
            if(typeof e.error === 'object'){
              let keys = Object.keys(e.error);

--- a/index.js
+++ b/index.js
@@ -129,7 +129,7 @@ class RobinHood{
 
          return self.parseResult(result);
       }catch(e){
-         console.error(e)
+         console.error(e.error)
          console.trace('Trace...')
          if('error' in e){
            if(typeof e.error === 'object'){


### PR DESCRIPTION
During testing found a bug when trying to cancel an order. Canceling order method should be POST, not GET.

Also confirmed in docs: https://github.com/sanko/Robinhood/blob/master/Order.md#cancel-an-order

By the way, great work on this library. I love that its modernized with async/await.
